### PR TITLE
Add landing page and basic login/signup flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,20 @@
-import React from 'react'
+import React, { useState } from 'react'
+import Landing from './components/Landing'
+import SignUpForm from './components/SignUpForm'
+import LoginForm from './components/LoginForm'
+
+type Page = 'landing' | 'signup' | 'login'
 
 export default function App() {
-  return (
-    <main>
-      <h1>MedAI</h1>
-      <p>Welcome to the MedAI React app.</p>
-    </main>
-  )
+  const [page, setPage] = useState<Page>('landing')
+
+  if (page === 'signup') {
+    return <SignUpForm onLogin={() => setPage('login')} onBack={() => setPage('landing')} />
+  }
+
+  if (page === 'login') {
+    return <LoginForm onSignUp={() => setPage('signup')} onBack={() => setPage('landing')} />
+  }
+
+  return <Landing onLogin={() => setPage('login')} onSignUp={() => setPage('signup')} />
 }

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+interface LandingProps {
+  onLogin: () => void
+  onSignUp: () => void
+}
+
+export default function Landing({ onLogin, onSignUp }: LandingProps) {
+  return (
+    <section>
+      <h1>MedAI</h1>
+      <p>Welcome to MedAI, your AI-powered medical assistant.</p>
+      <ul>
+        <li>Symptom checker powered by machine learning</li>
+        <li>Medication reminders and tracking</li>
+        <li>Secure health record storage</li>
+      </ul>
+      <div>
+        <button type="button" onClick={onSignUp}>Get Started</button>
+        <p>
+          Already have an account?{' '}
+          <button type="button" onClick={onLogin}>Log in</button>
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+
+interface LoginFormProps {
+  onSignUp: () => void
+  onBack: () => void
+}
+
+export default function LoginForm({ onSignUp, onBack }: LoginFormProps) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    alert(`Log in with ${email}`)
+  }
+
+  return (
+    <section>
+      <h2>Log in</h2>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <button type="submit">Log In</button>
+      </form>
+      <p>
+        Need an account?{' '}
+        <button type="button" onClick={onSignUp}>Sign up</button>
+      </p>
+      <button type="button" onClick={onBack}>Back</button>
+    </section>
+  )
+}

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+
+interface SignUpFormProps {
+  onLogin: () => void
+  onBack: () => void
+}
+
+export default function SignUpForm({ onLogin, onBack }: SignUpFormProps) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    alert(`Sign up with ${email}`)
+  }
+
+  return (
+    <section>
+      <h2>Create your account</h2>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <button type="submit">Sign Up</button>
+      </form>
+      <p>
+        Already have an account?{' '}
+        <button type="button" onClick={onLogin}>Log in</button>
+      </p>
+      <button type="button" onClick={onBack}>Back</button>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add landing screen highlighting key MedAI features
- implement simple signup and login forms with navigation
- connect forms to main app navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a836316908330a8f6b61b2f78d762