### PR TITLE
Add landing page and basic login/signup flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,20 @@
-import React from 'react'
+import React, { useState } from 'react'
+import Landing from './components/Landing'
+import SignUpForm from './components/SignUpForm'
+import LoginForm from './components/LoginForm'
+
+type Page = 'landing' | 'signup' | 'login'
 
 export default function App() {
-  return (
-    <main>
-      <h1>MedAI</h1>
-      <p>Welcome to the MedAI React app.</p>
-    </main>
-  )
+  const [page, setPage] = useState<Page>('landing')
+
+  if (page === 'signup') {
+    return <SignUpForm onLogin={() => setPage('login')} onBack={() => setPage('landing')} />
+  }
+
+  if (page === 'login') {
+    return <LoginForm onSignUp={() => setPage('signup')} onBack={() => setPage('landing')} />
+  }
+
+  return <Landing onLogin={() => setPage('login')} onSignUp={() => setPage('signup')} />
 }

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+interface LandingProps {
+  onLogin: () => void
+  onSignUp: () => void
+}
+
+export default function Landing({ onLogin, onSignUp }: LandingProps) {
+  return (
+    <section className="glass-card">
+      <h1>MedAI</h1>
+      <p>Welcome to MedAI, your AI-powered medical assistant.</p>
+      <ul>
+        <li>Symptom checker powered by machine learning</li>
+        <li>Medication reminders and tracking</li>
+        <li>Secure health record storage</li>
+      </ul>
+      <div>
+        <button type="button" onClick={onSignUp}>Get Started</button>
+        <p>
+          Already have an account?{' '}
+          <button type="button" onClick={onLogin}>Log in</button>
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+
+interface LoginFormProps {
+  onSignUp: () => void
+  onBack: () => void
+}
+
+export default function LoginForm({ onSignUp, onBack }: LoginFormProps) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    alert(`Log in with ${email}`)
+  }
+
+  return (
+    <section className="glass-card">
+      <h2>Log in</h2>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <button type="submit">Log In</button>
+      </form>
+      <p>
+        Need an account?{' '}
+        <button type="button" onClick={onSignUp}>Sign up</button>
+      </p>
+      <button type="button" onClick={onBack}>Back</button>
+    </section>
+  )
+}

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+
+interface SignUpFormProps {
+  onLogin: () => void
+  onBack: () => void
+}
+
+export default function SignUpForm({ onLogin, onBack }: SignUpFormProps) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    alert(`Sign up with ${email}`)
+  }
+
+  return (
+    <section className="glass-card">
+      <h2>Create your account</h2>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <button type="submit">Sign Up</button>
+      </form>
+      <p>
+        Already have an account?{' '}
+        <button type="button" onClick={onLogin}>Log in</button>
+      </p>
+      <button type="button" onClick={onBack}>Back</button>
+    </section>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,78 @@ body {
   margin: 0;
   font-family: system-ui, sans-serif;
   line-height: 1.5;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: linear-gradient(135deg, #6e8efb, #a777e3);
+  color: #fff;
 }
 
-main {
+/* glassmorphism container */
+.glass-card {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
   padding: 2rem;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  width: 90%;
+  max-width: 400px;
   text-align: center;
+}
+
+@media (min-width: 768px) {
+  .glass-card {
+    max-width: 500px;
+  }
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  font-weight: 500;
+}
+
+input {
+  padding: 0.5rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+  cursor: pointer;
+}
+
+button:hover {
+  background: rgba(255, 255, 255, 0.4);
+}
+
+ul {
+  text-align: left;
+  padding-left: 1.2rem;
+}
+
+p {
+  margin-top: 1rem;
+}
+
+h1,
+h2 {
+  margin-top: 0;
 }


### PR DESCRIPTION
## Summary
- add landing screen highlighting key MedAI features
- implement simple signup and login forms with navigation
- style landing and auth pages with responsive glassmorphism

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a836316908330a8f6b61b2f78d762