### PR TITLE
Add landing page with feature showcase and basic login/signup flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,20 @@
-import React from 'react'
+import React, { useState } from 'react'
+import Landing from './components/Landing'
+import SignUpForm from './components/SignUpForm'
+import LoginForm from './components/LoginForm'
+
+type Page = 'landing' | 'signup' | 'login'
 
 export default function App() {
-  return (
-    <main>
-      <h1>MedAI</h1>
-      <p>Welcome to the MedAI React app.</p>
-    </main>
-  )
+  const [page, setPage] = useState<Page>('landing')
+
+  if (page === 'signup') {
+    return <SignUpForm onLogin={() => setPage('login')} onBack={() => setPage('landing')} />
+  }
+
+  if (page === 'login') {
+    return <LoginForm onSignUp={() => setPage('signup')} onBack={() => setPage('landing')} />
+  }
+
+  return <Landing onLogin={() => setPage('login')} onSignUp={() => setPage('signup')} />
 }

--- a/src/assets/ai-image.svg
+++ b/src/assets/ai-image.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25M18.364 5.636l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 21v-2.25m-6.364-.386l1.591-1.591M3 12h2.25m.386-6.364l1.591 1.591M8.25 12a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z" />
+</svg>

--- a/src/assets/asset-upload.svg
+++ b/src/assets/asset-upload.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M9 15l3-3m0 0 3 3m-3-3v6m5.25-7.5A3.75 3.75 0 0012 5.25a3.75 3.75 0 00-3.75 3.75A3.75 3.75 0 004.5 12c0 2.07 1.68 3.75 3.75 3.75h12.75a2.25 2.25 0 000-4.5h-2.25z" />
+</svg>

--- a/src/assets/cloud-library.svg
+++ b/src/assets/cloud-library.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3 7.5A2.25 2.25 0 015.25 5.25h4.5l1.5 1.5h7.5A2.25 2.25 0 0121 9v7.5a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 16.5V7.5z" />
+</svg>

--- a/src/assets/social-seo.svg
+++ b/src/assets/social-seo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 3a7.5 7.5 0 006.15 13.65z" />
+</svg>

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+
+import assetUpload from '../assets/asset-upload.svg'
+import aiImage from '../assets/ai-image.svg'
+import socialSeo from '../assets/social-seo.svg'
+import cloudLibrary from '../assets/cloud-library.svg'
+
+interface LandingProps {
+  onLogin: () => void
+  onSignUp: () => void
+}
+
+const features = [
+  {
+    img: assetUpload,
+    title: 'Brand Asset Uploads',
+    desc: 'Store logos and media for on-brand creation.',
+  },
+  {
+    img: aiImage,
+    title: 'AI Content Generator',
+    desc: 'Produce posts using your brand assets in seconds.',
+  },
+  {
+    img: socialSeo,
+    title: 'Social SEO Insights',
+    desc: 'Optimize captions and hashtags for maximum reach.',
+  },
+  {
+    img: cloudLibrary,
+    title: 'Cloud Asset Library',
+    desc: 'Access your creatives securely from anywhere.',
+  },
+]
+
+export default function Landing({ onLogin, onSignUp }: LandingProps) {
+  return (
+    <section className="glass-card">
+      <h1>MedAI</h1>
+      <p>Welcome to MedAI, your AI partner for social media content.</p>
+      <div className="feature-grid">
+        {features.map((f) => (
+          <div key={f.title} className="feature">
+            <img src={f.img} alt={f.title} />
+            <h3>{f.title}</h3>
+            <p>{f.desc}</p>
+          </div>
+        ))}
+      </div>
+      <div>
+        <button type="button" onClick={onSignUp}>Get Started</button>
+        <p>
+          Already have an account?{' '}
+          <button type="button" onClick={onLogin}>Log in</button>
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react'
+
+interface LoginFormProps {
+  onSignUp: () => void
+  onBack: () => void
+}
+
+export default function LoginForm({ onSignUp, onBack }: LoginFormProps) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    alert(`Log in with ${email}`)
+  }
+
+  return (
+    <section className="glass-card">
+      <h2>Log in</h2>
+      <p>Access your brand library and create new posts.</p>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <button type="submit">Log In</button>
+      </form>
+      <p>
+        Need an account?{' '}
+        <button type="button" onClick={onSignUp}>Sign up</button>
+      </p>
+      <button type="button" onClick={onBack}>Back</button>
+    </section>
+  )
+}

--- a/src/components/SignUpForm.tsx
+++ b/src/components/SignUpForm.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react'
+
+interface SignUpFormProps {
+  onLogin: () => void
+  onBack: () => void
+}
+
+export default function SignUpForm({ onLogin, onBack }: SignUpFormProps) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    alert(`Sign up with ${email}`)
+  }
+
+  return (
+    <section className="glass-card">
+      <h2>Create your account</h2>
+      <p>Upload brand assets and start generating content.</p>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <label>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <button type="submit">Sign Up</button>
+      </form>
+      <p>
+        Already have an account?{' '}
+        <button type="button" onClick={onLogin}>Log in</button>
+      </p>
+      <button type="button" onClick={onBack}>Back</button>
+    </section>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,112 @@ body {
   margin: 0;
   font-family: system-ui, sans-serif;
   line-height: 1.5;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: linear-gradient(135deg, #6e8efb, #a777e3);
+  color: #fff;
 }
 
-main {
+/* glassmorphism container */
+.glass-card {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
   padding: 2rem;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  width: 90%;
+  max-width: 600px;
   text-align: center;
+}
+
+@media (min-width: 768px) {
+  .glass-card {
+    max-width: 800px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .glass-card {
+    max-width: 900px;
+  }
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  font-weight: 500;
+}
+
+input {
+  padding: 0.5rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+  cursor: pointer;
+}
+
+button:hover {
+  background: rgba(255, 255, 255, 0.4);
+}
+
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  margin: 2rem 0;
+}
+
+.feature {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.feature img {
+  width: 64px;
+  height: 64px;
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width: 768px) {
+  .feature-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .feature-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+p {
+  margin-top: 1rem;
+}
+
+h1,
+h2 {
+  margin-top: 0;
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- highlight social media manager workflow on landing screen with new asset-upload, AI generator, SEO, and cloud library icons
- add explanatory taglines to login and sign-up forms referencing brand libraries and content generation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a836316908330a8f6b61b2f78d762